### PR TITLE
Adding support for uploading simple monitors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ be unique. Inside of the definition the following fields are recognized:
 
  * `name` - optional name of the monitor. Must be unique.
    If not set - a label is used instead.
- * `type` - required monitor type. So far only `SCRIPT_API` is supported
+ * `type` - required monitor type.
  * `frequency` - required monitor check frequency in minutes. Must be one of 1, 5, 10, 15, 30, 60, 360, 720, or 1440 (this is a limitation on the New Relic side)
  * `locations` - required list of locations for checks.
    Full list of supported locations available in New Relic documentation:
@@ -102,6 +102,8 @@ Python package installs a runnable script called *newrelic-cli*.
 Currently the following actions are supported:
 
  * `upload-monitors` - uploads all monitors described in the configuration file.
+   Filter regex limiting scope can be supplied using `--filter` or `-f` options.
+ * `upload-simple-monitors` - uploads all simple monitors described in the configuration file.
    Filter regex limiting scope can be supplied using `--filter` or `-f` options.
  * `delete-monitos` - deletes all monitors that match filter provided in
    `--filter` or `-f` option. By default doesn't match on anything.

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ in the following format:
     :code: yaml
 
 By default *newrelic-cli* will look for secrets config in the file:
-`~/.new_relic/secrets.yaml`. This setting can be overriden with `--secrets-file`
+`~/.new_relic/secret.yaml`. This setting can be overriden with `--secrets-file`
 command-line flag
 
 monitors

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -10,6 +10,15 @@ monitors:
     alert_policy: PagerDuty
     script_file:
       name: "example/hello.js"
+  test_simple_ping:
+    name: Testing simple ping monitor
+    type: SIMPLE
+    frequency: 60
+    uri: https://www.example.com/
+    locations:
+        - AWS_US_WEST_1
+    status: disabled
+    alert_policy: Email Policy
   bar:
     name: I am a monitor with templated script
     type: SCRIPT_API

--- a/newrelic_cli/cli.py
+++ b/newrelic_cli/cli.py
@@ -307,6 +307,7 @@ def main():
         nargs="?",
         choices=[
             'upload-monitors',
+            'upload-simple-monitors',
             'delete-monitors',
             'list-monitors',
             'upload-alert-policies',

--- a/newrelic_cli/cli.py
+++ b/newrelic_cli/cli.py
@@ -383,6 +383,14 @@ def main():
         #  chdir into cofnig file folder
         os.chdir(os.path.dirname(args.config_file.name))
         upload_monitors(secrets.api_key, config, args.filter)
+    elif args.function == 'upload-simple-monitors':
+        args = parser.parse_args(sub_args)
+        config = get_config(args.config_file)
+        secrets = get_secrets(args.secrets_file)
+        # As paths to the script files in config are relative
+        #  chdir into cofnig file folder
+        os.chdir(os.path.dirname(args.config_file.name))
+        upload_simple_monitors(secrets.api_key, config, args.filter)
     elif args.function == 'delete-monitors':
         args = parser.parse_args(sub_args)
         config = get_config(args.config_file)

--- a/newrelic_cli/synthetics.py
+++ b/newrelic_cli/synthetics.py
@@ -72,6 +72,44 @@ class SyntheticsClient(NewRelicBaseClient):
         )
         return r.json()
 
+    def create_simple_monitor(self, name,
+                              type='SIMPLE',
+                              frequency=30,
+                              uri="https://www.example.com",
+                              locations=['AWS_US_WEST_1'],
+                              status='DISABLED',
+                              slaThreshold=None
+                              ):
+        """
+        Creates a monitor. If creation is successful -
+         the monitor object is returned
+        """
+        url = '{}/v3/monitors'.format(self.base_url)
+        payload = {
+            'name': name,
+            'type': type,
+            'frequency': frequency,
+            'uri': uri,
+            'locations': locations,
+            'status': status,
+        }
+        if slaThreshold:
+            payload['slaThreshold'] = slaThreshold
+
+        r = self._post(
+            url,
+            headers=self.default_headers,
+            timeout=self.timeout,
+            json=payload
+        )
+        location = r.headers['location']
+        r = self._get(
+            location,
+            headers=self.default_headers,
+            timeout=self.timeout
+        )
+        return r.json()
+
     def update_monitor(self, current_name,
                        new_name=None,
                        frequency=None,
@@ -166,7 +204,7 @@ class SyntheticsClient(NewRelicBaseClient):
         except ItemNotFoundError:
             raise ItemNotFoundError(
                 'Script for monitor {} not found'
-                .format(name)
+                    .format(name)
             )
         script_base64 = r.json()['scriptText']
         script = base64.b64decode(script_base64)


### PR DESCRIPTION
We needed to automate uploading simple monitors so updated and added options and methods to check if script was not given it will be considered as an simple monitor.
Does not have the adding advanced options e.g. check for ssl